### PR TITLE
Single recipe tags

### DIFF
--- a/component/recipe-tags/Tag.js
+++ b/component/recipe-tags/Tag.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import Chip from '@mui/material/Chip';
-
+import classes from './tag.module.css';
 const Tag = ({ tagName }) => {
   return (
-    <li>
+    <li className={classes.listItem}>
       <Chip label={tagName} />
     </li>
   );

--- a/component/recipe-tags/Tag.js
+++ b/component/recipe-tags/Tag.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import Chip from '@mui/material/Chip';
 import classes from './tag.module.css';
+
+/**
+ * Expects tagName from the the tagsContainer component
+ * @param {string} tagName
+ * @returns tag list item
+ */
 const Tag = ({ tagName }) => {
   return (
     <li className={classes.listItem}>

--- a/component/recipe-tags/TagsContainer.js
+++ b/component/recipe-tags/TagsContainer.js
@@ -1,24 +1,22 @@
 import React from 'react';
 import Tag from './Tag';
+import classes from './TagsContainer.module.css';
 
 const tags = [
-  [
-    'Dessert',
-    'Low Protein',
-    'Low Cholesterol',
-    'Healthy',
-    'Free Of...',
-    'Summer',
-    'Weeknight',
-    'Freezer',
-    'Easy',
-  ],
+  'Dessert',
+  'Low Protein',
+  'Low Cholesterol',
+  'Healthy',
+  'Free Of...',
+  'Summer',
+  'Weeknight',
+  'Freezer',
+  'Easy',
 ];
-
 const TagsContainer = () => {
-  //expecting {tags} as argument
+  //expecting {tags} as argument when
   return (
-    <ul>
+    <ul className={classes.container}>
       {tags.map((tagName, index) => {
         return <Tag key={index} tagName={tagName}></Tag>;
       })}

--- a/component/recipe-tags/TagsContainer.js
+++ b/component/recipe-tags/TagsContainer.js
@@ -2,6 +2,8 @@ import React from 'react';
 import Tag from './Tag';
 import classes from './TagsContainer.module.css';
 
+//Please remove dummy tags data once tag list from the individual recipes
+//can be fed into the TagsContainer component.
 const tags = [
   'Dessert',
   'Low Protein',
@@ -13,6 +15,10 @@ const tags = [
   'Freezer',
   'Easy',
 ];
+/**
+ * Expects tags list from a single recipe and displays tags for each individual recipe
+ * @returns list of tags
+ */
 const TagsContainer = () => {
   //expecting {tags} as argument when
   return (

--- a/component/recipe-tags/TagsContainer.module.css
+++ b/component/recipe-tags/TagsContainer.module.css
@@ -1,0 +1,4 @@
+.container {
+  display: flex;
+  gap: 1rem;
+}

--- a/component/recipe-tags/tag.module.css
+++ b/component/recipe-tags/tag.module.css
@@ -1,0 +1,3 @@
+.listItem {
+  list-style: none;
+}


### PR DESCRIPTION
Updated the display of the single recipe tags. Currently, the components (tagsContainer and tags) still use dummy data as a single recipe page has not yet been created. Need data from the single recipe page (fetched from the database) to feed into these components.